### PR TITLE
Manage /etc/issue.sshd

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,37 +3,46 @@
 # This module manages /etc/motd and /etc/issue.
 #
 class motd (
-  $motd_file         = '/etc/motd',
-  $motd_ensure       = 'file',
-  $motd_owner        = 'root',
-  $motd_group        = 'root',
-  $motd_mode         = '0644',
-  $motd_content      = undef,
-  $issue_file        = '/etc/issue',
-  $issue_ensure      = 'file',
-  $issue_owner       = 'root',
-  $issue_group       = 'root',
-  $issue_mode        = '0644',
-  $issue_content     = undef,
-  $issue_net_file    = '/etc/issue.net',
-  $issue_net_ensure  = 'file',
-  $issue_net_owner   = 'root',
-  $issue_net_group   = 'root',
-  $issue_net_mode    = '0644',
-  $issue_net_content = undef,
+  $motd_file          = '/etc/motd',
+  $motd_ensure        = 'file',
+  $motd_owner         = 'root',
+  $motd_group         = 'root',
+  $motd_mode          = '0644',
+  $motd_content       = undef,
+  $issue_file         = '/etc/issue',
+  $issue_ensure       = 'file',
+  $issue_owner        = 'root',
+  $issue_group        = 'root',
+  $issue_mode         = '0644',
+  $issue_content      = undef,
+  $issue_net_file     = '/etc/issue.net',
+  $issue_net_ensure   = 'file',
+  $issue_net_owner    = 'root',
+  $issue_net_group    = 'root',
+  $issue_net_mode     = '0644',
+  $issue_net_content  = undef,
+  $issue_sshd_file    = '/etc/issue.sshd',
+  $issue_sshd_ensure  = 'file',
+  $issue_sshd_owner   = 'root',
+  $issue_sshd_group   = 'root',
+  $issue_sshd_mode    = '0644',
+  $issue_sshd_content = undef,
 ) {
 
   validate_re($motd_ensure,'^(file|present|absent)$','vim::motd_ensure must be <file>, <present> or <absent>.')
   validate_re($issue_ensure,'^(file|present|absent)$','vim::issue_ensure must be <file>, <present> or <absent>.')
   validate_re($issue_net_ensure,'^(file|present|absent)$','vim::issue_net_ensure must be <file>, <present> or <absent>.')
+  validate_re($issue_sshd_ensure,'^(file|present|absent)$','vim::issue_sshd_ensure must be <file>, <present> or <absent>.')
 
   validate_absolute_path($motd_file)
   validate_absolute_path($issue_file)
   validate_absolute_path($issue_net_file)
+  validate_absolute_path($issue_sshd_file)
 
   validate_re($motd_mode,'^[0-7]{4}$','vim::motd_mode must be a valid four digit mode in octal notation.')
   validate_re($issue_mode,'^[0-7]{4}$','vim::issue_mode must be a valid four digit mode in octal notation.')
   validate_re($issue_net_mode,'^[0-7]{4}$','vim::issue_net_mode must be a valid four digit mode in octal notation.')
+  validate_re($issue_sshd_mode,'^[0-7]{4}$','vim::issue_sshd_mode must be a valid four digit mode in octal notation.')
 
   file { 'motd':
     ensure  => $motd_ensure,
@@ -60,5 +69,14 @@ class motd (
     group   => $issue_net_group,
     mode    => $issue_net_mode,
     content => $issue_net_content,
+  }
+
+  file { 'issue_sshd':
+    ensure  => $issue_sshd_ensure,
+    path    => $issue_sshd_file,
+    owner   => $issue_sshd_owner,
+    group   => $issue_sshd_group,
+    mode    => $issue_sshd_mode,
+    content => $issue_sshd_content,
   }
 }


### PR DESCRIPTION
I was implementing this module to manage the /etc/issue.sshd file. I could change the /etc/issue.net file resource to manage /etc/issue.sshd, however, my configuration also requires that /etc/issue.net, and /etc/issue be managed. Since this module manages /etc/issue.net, I don't think it's unreasonably for it to also manage /etc/issue.sshd.