### PR TITLE
Puppet data types

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   repositories:
     stdlib:
       repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
-      ref: '4.6.0'
+      ref: '4.13.1'
   symlinks:
     motd: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,101 +1,21 @@
 ---
 language: ruby
 
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.3.1
-
-env:
-  matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
-    - PUPPET_GEM_VERSION="~> 3.4.0"
-    - PUPPET_GEM_VERSION="~> 3.5.0"
-    - PUPPET_GEM_VERSION="~> 3.6.0"
-    - PUPPET_GEM_VERSION="~> 3.7.0"
-    - PUPPET_GEM_VERSION="~> 3.8.0"
-    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-    - PUPPET_GEM_VERSION="~> 4.0.0"
-    - PUPPET_GEM_VERSION="~> 4.1.0"
-    - PUPPET_GEM_VERSION="~> 4.2.0"
-    - PUPPET_GEM_VERSION="~> 4.3.0"
-    - PUPPET_GEM_VERSION="~> 4.4.0"
-    - PUPPET_GEM_VERSION="~> 4.5.0"
-    - PUPPET_GEM_VERSION="~> 4.6.0"
-    - PUPPET_GEM_VERSION="~> 4.7.0"
-    - PUPPET_GEM_VERSION="~> 4.8.0"
-    - PUPPET_GEM_VERSION="~> 4.9.0"
-    - PUPPET_GEM_VERSION="~> 4"
-
 sudo: false
 
 script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.1.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.2.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.3.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.4.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.5.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4.6.0"
-    - rvm: 1.8.7
+  include:
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION="~> 4.7.0"
-    - rvm: 1.8.7
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION="~> 4.8.0"
-    - rvm: 1.8.7
+    - rvm: 2.1.9
       env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4.9.0"
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 1.9.3
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 4"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.2.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.3.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.4.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.5.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.6.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.7.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3.8.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - rvm: 2.4.0
+      env: PUPPET_GEM_VERSION="~> 5.0"
 
 notifications:
   email: false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,37 +3,25 @@
 # This module manages /etc/motd and /etc/issue.
 #
 class motd (
-  $motd_file         = '/etc/motd',
-  $motd_ensure       = 'file',
-  $motd_owner        = 'root',
-  $motd_group        = 'root',
-  $motd_mode         = '0644',
-  $motd_content      = undef,
-  $issue_file        = '/etc/issue',
-  $issue_ensure      = 'file',
-  $issue_owner       = 'root',
-  $issue_group       = 'root',
-  $issue_mode        = '0644',
-  $issue_content     = undef,
-  $issue_net_file    = '/etc/issue.net',
-  $issue_net_ensure  = 'file',
-  $issue_net_owner   = 'root',
-  $issue_net_group   = 'root',
-  $issue_net_mode    = '0644',
-  $issue_net_content = undef,
+  Stdlib::Absolutepath $motd_file                     = '/etc/motd',
+  Enum['file', 'present', 'absent'] $motd_ensure      = 'file',
+  String $motd_owner                                  = 'root',
+  String $motd_group                                  = 'root',
+  Pattern[/^[0-7]{4}$/] $motd_mode                    = '0644',
+  Optional[String] $motd_content                      = undef,
+  Stdlib::Absolutepath $issue_file                    = '/etc/issue',
+  Enum['file', 'present', 'absent'] $issue_ensure     = 'file',
+  String $issue_owner                                 = 'root',
+  String $issue_group                                 = 'root',
+  Pattern[/^[0-7]{4}$/] $issue_mode                   = '0644',
+  Optional[String] $issue_content                     = undef,
+  Stdlib::Absolutepath $issue_net_file                = '/etc/issue.net',
+  Enum['file', 'present', 'absent'] $issue_net_ensure = 'file',
+  String $issue_net_owner                             = 'root',
+  String $issue_net_group                             = 'root',
+  Pattern[/^[0-7]{4}$/] $issue_net_mode               = '0644',
+  Optional[String] $issue_net_content                 = undef,
 ) {
-
-  validate_re($motd_ensure,'^(file|present|absent)$','vim::motd_ensure must be <file>, <present> or <absent>.')
-  validate_re($issue_ensure,'^(file|present|absent)$','vim::issue_ensure must be <file>, <present> or <absent>.')
-  validate_re($issue_net_ensure,'^(file|present|absent)$','vim::issue_net_ensure must be <file>, <present> or <absent>.')
-
-  validate_absolute_path($motd_file)
-  validate_absolute_path($issue_file)
-  validate_absolute_path($issue_net_file)
-
-  validate_re($motd_mode,'^[0-7]{4}$','vim::motd_mode must be a valid four digit mode in octal notation.')
-  validate_re($issue_mode,'^[0-7]{4}$','vim::issue_mode must be a valid four digit mode in octal notation.')
-  validate_re($issue_net_mode,'^[0-7]{4}$','vim::issue_net_mode must be a valid four digit mode in octal notation.')
 
   file { 'motd':
     ensure  => $motd_ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -83,12 +83,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.2.0 < 5.0.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -88,6 +88,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.13.1 < 6.0.0"}
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -135,19 +135,19 @@ describe 'motd' do
         :name    => %w(motd_file issue_file issue_net_file),
         :valid   => %w(/absolute/filepath /absolute/directory/),
         :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
-        :message => 'is not an absolute path',
+        :message => '(expects a match for Variant\[Stdlib::Windowspath|expects a Stdlib::Absolutepath = Variant)', # Puppet 4|5
       },
       'regex ensure' => {
         :name    => %w(motd_ensure issue_ensure issue_net_ensure),
         :valid   => %w(file present absent),
         :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
-        :message => 'must be <file>, <present> or <absent>',
+        :message => 'match for Enum\[\'absent\', \'file\', \'present\'\]',
       },
       'regex file mode' => {
         :name    => %w(motd_mode issue_mode issue_net_mode),
         :valid   => %w(0755 0644 1755 0242),
         :invalid => ['string', '755', 980, '0980', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
-        :message => 'must be a valid four digit mode in octal notation',
+        :message => 'expects a match for Pattern\[\/\^\[0-7\]\{4\}\$\/\]',
       },
     }
 


### PR DESCRIPTION
Major change mostly motivated to stop using validate functions which emit deprecation warnings on >= 4.13.0.