### PR TITLE
Numerous updates

### DIFF
--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,3 +1,2 @@
 ---
- motd::motd_directory_ensure: absent
- 
+motd::motd_directory_ensure: absent

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -1,0 +1,3 @@
+---
+ motd::motd_directory_ensure: absent
+ 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,24 @@
 # @param motd_content
 #   Content of motd file.
 #
+# @param motd_directory_ensure
+#   Ensure attribute for directory resource. Valid values are 'directory' and 'absent'
+#
+# @param motd_directory
+#   Path to MOTD directory
+#
+# @param motd_directory_owner
+#   motd directory owner
+#
+# @param motd_directory_group
+#   motd directory group
+#
+# @param motd_directory_mode
+#   motd directory mode
+#
+# @param motd_directory_purge
+#   Sets whether to purge unmanaged files under motd module_directory
+#
 # @param issue_file
 #   Path to issue.
 #
@@ -61,6 +79,12 @@ class motd (
   String[1]                         $motd_group        = 'root',
   Stdlib::Filemode                  $motd_mode         =  '0644',
   Optional[String[1]]               $motd_content      = undef,
+  Enum['directory', 'absent']       $motd_directory_ensure  = 'directory',
+  Stdlib::Absolutepath              $motd_directory         = '/etc/motd.d',
+  String[1]                         $motd_directory_owner   = 'root',
+  String[1]                         $motd_directory_group   = 'root',
+  Stdlib::Filemode                  $motd_directory_mode    =  '0755',
+  Boolean                           $motd_directory_purge   = true,
   Stdlib::Absolutepath              $issue_file        = '/etc/issue',
   Enum['file', 'present', 'absent'] $issue_ensure      = 'file',
   String                            $issue_owner       = 'root',
@@ -81,6 +105,17 @@ class motd (
     group   => $motd_group,
     mode    => $motd_mode,
     content => $motd_content,
+  }
+
+  file { 'motd.d':
+    ensure  => $motd_directory_ensure,
+    path    => $motd_directory,
+    owner   => $motd_directory_owner,
+    group   => $motd_directory_group,
+    mode    => $motd_directory_mode,
+    purge   => $motd_directory_purge,
+    force   => $motd_directory_purge,
+    recurse => $motd_directory_purge,
   }
 
   file { 'issue':

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.22.0 < 9.0.0"
+      "version_requirement": ">= 4.22.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -25,34 +25,37 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "5",
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
+        "7",
+        "8",
+        "9"
       ]
     },
     {
-      "operatingsystem": "Scientific",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "5",
-        "6",
-        "7"
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
       ]
     },
     {
@@ -90,7 +93,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "description": "Manage /etc/motd, /etc/issue, and /etc/issue.net files",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,6 +21,21 @@ describe 'motd' do
     end
 
     it do
+      is_expected.to contain_file('motd.d').with(
+        {
+          'ensure'  => 'directory',
+          'path'    => '/etc/motd.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'purge'   => true,
+          'force'   => true,
+          'recurse' => true,
+        },
+      )
+    end
+
+    it do
       is_expected.to contain_file('issue').with(
         {
           'ensure'  => 'file',


### PR DESCRIPTION
* Manage /etc/motd.d which is present on newer versions of PAM
* Drop EOL EL OS support
* Add EL9 support
* Support Puppet 7 and 8
* Support stdlib 9.x